### PR TITLE
Avoid rewriting CMakeLists.txt if unnecessary

### DIFF
--- a/quark/utils.py
+++ b/quark/utils.py
@@ -25,11 +25,6 @@ def load_conf(folder):
     else:
         return None
 
-def walk_tree(root, callback):
-    for c in root.children:
-        walk_tree(c, callback)
-    callback(root)
-
 def fork(*args, **kwargs):
     sys.stdout.write(' '.join(args[0]) + '\n')
     sys.stdout.flush()


### PR DESCRIPTION
A CMakeLists.txt rewrite can trigger a full rebuild; this fix tries to
avoid it unless really necessary:

- added a check to avoid rewriting a CMakeLists.txt with the exact same
  content;
- make sure to re-generate the same output for CMakeLists.txt given the
  same input; this requires some care, as Node objects and options are
  stored into set/dict, so iteration order is not deterministic (and
  indeed changes at each run). For this reason, we sort them when
  iterating to write the CMakeLists.txt file.

Incidentally, this commit slighly simplifies the generation logic (less
special cases) and gets rid of the now-unused walk_tree function.