### PR TITLE
Fix shallow checkout commit ref

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -281,7 +281,7 @@ class GitSubproject(Subproject):
             # Needed essentially for the shallow case, as for full clones the
             # git clone -n + git checkout would suffice
             if self.ref != 'origin/HEAD':
-                extra_opts += ['-b', self.noremote_ref]
+                extra_opts += ['-b', self.noremote_ref()]
             fork(['git', 'clone', '-n'] + extra_opts + ['--', self.url.geturl(), self.directory])
             with cd(self.directory):
                 fork(['git', 'checkout', self.ref, '--'])


### PR DESCRIPTION
Currently quark used plain `git clone` + `git checkout` to extract the
required revision; this unfortunately is broken for shallow checkouts,
as `git clone` is performed with `--depth=1`, extracting just the HEAD
commit, and thus the following `git checkout` fails when asking for
anything but origin/HEAD.

This fix changes the checkout logic:

- if the required ref is a branch or tag, `git clone -b` is used, which
  should extract straight the required ref (with or without
  `--depth=1`); this fixes the shallow case with non-commit refs and
  should also speed up the non-shallow checkouts (as there's no need to
  _first_ extract HEAD and _then_ switch to the required ref);
- in the case of commit ref, `-b` does not work, and we use a workaround
  explained at https://stackoverflow.com/a/43136160/214671; the steps
  done normally by `git clone` are emulated "by hand": an empty git
  repository is created, we fetch just what we need in case of a shallow
  clone, and checkout the required commit.