### PR TITLE
quark freeze: generate a deterministic freeze.quark

### DIFF
--- a/quark/freeze.py
+++ b/quark/freeze.py
@@ -16,7 +16,7 @@ def run():
     for name, mod in modules.items():
         freeze_conf[name] = mod.url_from_checkout()
     with open(join(root.directory, freeze_file), 'w') as f:
-        json.dump(freeze_conf, f, indent=4)
+        json.dump(freeze_conf, f, indent=4, sort_keys = True)
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Currently quark generates a different `freeze.quark` each time `quark.freeze` is run, as we are dumping a Python `dict`, that has no inherent ordering before Python 3.7. This is problematic as it dirties the sandbox when running `quark freeze` for projects with an always-commited freeze file, and in general it makes checking diffs of quark.freeze more of a hassle than it should be.

This PR makes sure that quark.freeze is deterministically generated, solving these problems.

(This is part of fixing #24)