### PR TITLE
SvnSubproject: populate rev attribute even when the svn URL uses "regular" peg-revision syntax and not our #fragment stuff

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -540,18 +540,22 @@ class SvnSubproject(Subproject):
         super().__init__(name, directory, options, conf = {}, **kwargs)
         self.rev = 'HEAD'
         fragment = (url.fragment and Subproject._parse_fragment(url)) or {}
-        rev = fragment.get('rev', None)
-        branch = fragment.get('branch', None)
-        tag = fragment.get('tag', None)
-        if (branch or tag) and self.url.path.endswith('trunk'):
-            url = url._replace(path=self.url.path[:-5])
-        if branch:
-            url = url._replace(path=join(url.path, 'branches', branch))
-        elif tag:
-            url = url._replace(path=join(url.path, 'tags', tag))
-        if rev:
-            url = url._replace(path=url.path + '@' + rev)
-            self.rev = rev
+        if len(fragment):
+            rev = fragment.get('rev', None)
+            branch = fragment.get('branch', None)
+            tag = fragment.get('tag', None)
+            if (branch or tag) and self.url.path.endswith('trunk'):
+                url = url._replace(path=self.url.path[:-5])
+            if branch:
+                url = url._replace(path=join(url.path, 'branches', branch))
+            elif tag:
+                url = url._replace(path=join(url.path, 'tags', tag))
+            if rev:
+                url = url._replace(path=url.path + '@' + rev)
+                self.rev = rev
+        else:
+            if '@' in url.path:
+                self.rev = url.path.split('@')[-1]
         self.url = url._replace(fragment='')
 
     def same_checkout(self, other):


### PR DESCRIPTION
This makes sure that quark foreach's rev environment variable works correctly