### PR TITLE
bin/quark: prepend our path to the system paths instead of appending it

### DIFF
--- a/bin/quark
+++ b/bin/quark
@@ -4,7 +4,7 @@ import os
 import sys
 import importlib
 bin_dir = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(bin_dir, ".."))
+sys.path.insert(0, os.path.join(bin_dir, ".."))
 from quark import checkout, update, freeze, status
 from quark.entrypoints import commands, aliases
 


### PR DESCRIPTION
Fixes that if there was a system-installed `quark`, `bin/quark` would import the global `quark` module instead of the one from the sandbox.