### PR TITLE
Added -t/--type option to git foreach to filter by project type

### DIFF
--- a/quark/foreach.py
+++ b/quark/foreach.py
@@ -36,6 +36,11 @@ def run():
         help="Only print error messages"
     )
     parser.add_argument(
+        "-t", "--type",
+        action="append",
+        help="Only iterate on the projects of the given type (git/svn); if repeated, all the specified types are matched"
+    )
+    parser.add_argument(
         "command",
         action="store",
         nargs=1,
@@ -51,6 +56,8 @@ def run():
     for path, module in sorted(modules.items()):
         cmd_env = dict(os.environ)
         cmd_env.update(module.get_env_variables(toplevel=os.getcwd()))
+        if optlist.type and cmd_env['version_control'] not in optlist.type:
+            continue
 
         with DirectoryContext(module.directory):
             if not optlist.quiet:


### PR DESCRIPTION
this is useful as often a given command makes sense only for a specific
type of project; for example, it allows to simply do

    quark foreach -t git "git fetch -p"

to cleanup git repos instead of the more verbose

    quark foreach "if [ -d .git ]; then git fetch -p; fi"

or even more verbose alternatives based on the environment variables set
by quark foreach)