### PR TITLE
If quark.cmake is provided by a subproject, `include` it instead of doing `add_subdirectory`

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -695,9 +695,12 @@ def generate_cmake_script(source_dir, url=None, options=None, print_tree=False,u
                 process_module(c)
             # dump options and add to the generated CMakeLists.txt
             dump_options(module)
-            if module is not root and exists(join(module.directory, "CMakeLists.txt")):
+            if module is not root:
                 subdir = os.path.relpath(module.directory, subproject_dir)
-                cmakelists_rows.append('add_subdirectory(%s)\n' % cmake_escape(subdir))
+                if exists(join(module.directory, "quark.cmake")):
+                    cmakelists_rows.append('include(%s)\n' % cmake_escape(join(subdir, "quark.cmake")))
+                elif exists(join(module.directory, "CMakeLists.txt")):
+                    cmakelists_rows.append('add_subdirectory(%s)\n' % cmake_escape(subdir))
 
         process_module(root)
 


### PR DESCRIPTION
This provides a more nuanced hook for projects (namely, it doesn't suffer the same "cannot include multiple times" problems of `add_subdirectory`).

This is a first step toward fixing the `cmake_commons` mess (using `include` instead of `add_subdirectory` we can have an include-guard-like mechanism using a fake target).