### PR TITLE
Added support for ClangFormat

### DIFF
--- a/quark/checkout.py
+++ b/quark/checkout.py
@@ -1,7 +1,7 @@
 
 from urllib.parse import urlparse
 from argparse import ArgumentParser
-from .subproject import generate_cmake_script
+from .subproject import init_subprojects_dir
 from os.path import abspath, basename
 from .utils import parse_option
 from os import getcwd
@@ -24,7 +24,7 @@ def run():
             key, value = parse_option(option)
             options[key] = value
     source_dir = abspath(optlist.source_directory or (optlist.url and basename(urlparse(optlist.url).path)) or getcwd())
-    generate_cmake_script(source_dir, url, print_tree=optlist.verbose, options=options)
+    init_subprojects_dir(source_dir, url, print_tree=optlist.verbose, options=options)
 
 if __name__ == "__main__":
     run()

--- a/quark/mirror.py
+++ b/quark/mirror.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from .subproject import generate_cmake_script, Subproject
+from .subproject import Subproject
 from .utils import parse_option
 import os
 

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -681,6 +681,15 @@ class SvnSubproject(Subproject):
         # Svn doesn't support local sandbox ignore lists
         pass
 
+def generate_clang_format(subprojects_dir):
+    clangformat_data = """{
+"DisableFormat": true,
+"SortIncludes": false
+}
+"""
+    with open(join(subprojects_dir, '.clang-format'), 'w') as f:
+        f.write(clangformat_data)
+
 def generate_cmake_script(subproject_dir, root):
     cmakelists_rows = []
     processed = set()
@@ -742,4 +751,5 @@ def init_subprojects_dir(source_dir, url=None, options=None, print_tree=False,up
         subproject_dir = join(source_dir, conf.get("subprojects_dir", 'lib'))
 
         generate_cmake_script(subproject_dir, root)
+        generate_clang_format(subproject_dir)
 

--- a/quark/update.py
+++ b/quark/update.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from .subproject import generate_cmake_script, Subproject, url_from_directory
+from .subproject import init_subprojects_dir, Subproject, url_from_directory
 from .utils import parse_option
 from os import getcwd
 from .utils import catalog_urls_overrides
@@ -41,7 +41,7 @@ def run():
         root_url = url_from_directory(source_dir, include_commit = False)
         root = Subproject.create("root", root_url, source_dir, {}, toplevel = True)
         root.update(optlist.clean)
-    generate_cmake_script(source_dir, print_tree=optlist.verbose, options=options, clean=optlist.clean)
+    init_subprojects_dir(source_dir, print_tree=optlist.verbose, options=options, clean=optlist.clean)
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
When checking out/updating adds a `.clang-format` file to the subprojects dirs that disables formatting to avoid applying the coding style of the top level project to its dependencies when they don't contain a custom one.