### PR TITLE
Introduce quark up -f (or --clobber) to remove all existing subprojects dirs instead of trying to update them.

### DIFF
--- a/quark/update.py
+++ b/quark/update.py
@@ -22,6 +22,10 @@ def run():
             action="append", help="Overrides the specified catalog URL with the provided one")
     parser.add_argument("-C", "--clean", action='store_true', default=False,
             help="Clean the dependency directory if has local modifications")
+    parser.add_argument("-f", "--clobber", action='store_true', default=False,
+            help="Removes existing subprojects directories before update, to force starting " +
+            "from scratch instead of trying to update existing clones. Removed directories " +
+            "are actually moved under a clobbered.quark directory, that must not already exist.")
     optlist = parser.parse_args()
     source_dir = optlist.source_directory or getcwd()
     options = {}
@@ -41,7 +45,7 @@ def run():
         root_url = url_from_directory(source_dir, include_commit = False)
         root = Subproject.create("root", root_url, source_dir, {}, toplevel = True)
         root.update(optlist.clean)
-    generate_cmake_script(source_dir, print_tree=optlist.verbose, options=options, clean=optlist.clean)
+    generate_cmake_script(source_dir, print_tree=optlist.verbose, options=options, clean=optlist.clean, clobber = optlist.clobber)
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
This is particularly useful if we got in some situation from which quark cannot recover (e.g. remote changed).

Existing clones aren't really deleted, but are moved under a clobbered.quark directory, that must not already exist when quark up is invoked.