### PR TITLE
Allow the root not to have a configured remote

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -470,7 +470,10 @@ Please either remove the local clone, or fix its remote.""" % (self.directory, c
     @staticmethod
     def url_from_directory(directory, include_commit = True):
         with cd(directory):
-            origin = log_check_output(['git', 'remote', 'get-url', 'origin'], universal_newlines=True)[:-1]
+            try:
+                origin = log_check_output(['git', 'remote', 'get-url', 'origin'], universal_newlines=True)[:-1]
+            except CalledProcessError:
+                raise QuarkError("Cannot obtain remote")
             commit = log_check_output(['git', 'log', '-1', '--format=%H'], universal_newlines=True)[:-1]
         ret = 'git+%s' % (origin,)
         if include_commit:


### PR DESCRIPTION
the root wasn't ever required to be under a VCS, but still has a "project" object in the dependency tree for internal reasons; if it's actually under git, but doesn't have an origin remote (yet?), currently quark blows up, because the root repo is recognized as a git repo, but the `git remote get-url origin` call that is automatically done fails.

Notice that this kind of failure was already expected and ignored in `create_dependency_tree`, but it expected a `QuarkError`, while here we get a "raw" CalledProcessError.

To fix this, in case of failure of the command above we translate the error to a `QuarkError` instead, so that the error is not swallowed, but in this context is correctly ignored.