### PR TITLE
Add --fix-remotes option

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -198,7 +198,7 @@ main project abspath: %s""" % (name, uri, source_dir, target_dir_rp, source_dir_
         while len(stack):
             current_module = stack.pop()
             if current_module.external_project:
-                generate_cmake_script(current_module.directory, update = update)
+                generate_cmake_script(current_module.directory, update = update, clean = clean, clobber = clobber)
                 continue
             conf = load_conf(current_module.directory)
             if conf:

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -88,7 +88,7 @@ class Subproject:
         return res
 
     @staticmethod
-    def create_dependency_tree(source_dir, url=None, options=None, update=False, clean=False, clobber=False):
+    def create_dependency_tree(source_dir, url=None, options=None, update=False, clean=False, clobber=False, fix_remotes=False):
         # make sure the separator is present
         source_dir_rp = os.path.join(os.path.abspath(source_dir), '')
         clobber_backup_path = os.path.join(source_dir_rp, 'clobbered.quark')
@@ -158,7 +158,7 @@ main project abspath: %s""" % (name, uri, source_dir, target_dir_rp, source_dir_
                             backup_path = '%s.%d' % (backup_path_base, i)
                         print('%s already present; moving it to %s before new checkout' % (name, backup_path))
                         shutil.move(mod.directory, backup_path)
-                    mod.update(clean)
+                    mod.update(clean, fix_remotes)
             else:
                 if newmodule.exclude_from_cmake != mod.exclude_from_cmake:
                     children_conf = [join(parent.directory, dependency_file) for parent in mod.parents]
@@ -198,7 +198,7 @@ main project abspath: %s""" % (name, uri, source_dir, target_dir_rp, source_dir_
         while len(stack):
             current_module = stack.pop()
             if current_module.external_project:
-                generate_cmake_script(current_module.directory, update = update, clean = clean, clobber = clobber)
+                generate_cmake_script(current_module.directory, update = update, clean = clean, clobber = clobber, fix_remotes=fix_remotes)
                 continue
             conf = load_conf(current_module.directory)
             if conf:
@@ -705,8 +705,8 @@ class SvnSubproject(Subproject):
         # Svn doesn't support local sandbox ignore lists
         pass
 
-def generate_cmake_script(source_dir, url=None, options=None, print_tree=False,update=True, clean=False, clobber=False):
-    root, modules = Subproject.create_dependency_tree(source_dir, url, options, update=update, clean=clean, clobber=clobber)
+def generate_cmake_script(source_dir, url=None, options=None, print_tree=False,update=True, clean=False, clobber=False, fix_remotes = False):
+    root, modules = Subproject.create_dependency_tree(source_dir, url, options, update=update, clean=clean, clobber=clobber, fix_remotes = fix_remotes)
     if print_tree:
         print(json.dumps(root.toJSON(), indent=4))
     conf = load_conf(source_dir)

--- a/quark/update.py
+++ b/quark/update.py
@@ -26,6 +26,9 @@ def run():
             help="Removes existing subprojects directories before update, to force starting " +
             "from scratch instead of trying to update existing clones. Removed directories " +
             "are actually moved under a clobbered.quark directory, that must not already exist.")
+    parser.add_argument("-F", "--fix-remotes", action="store_true", default=False,
+            help="If the remote of a git subproject doesn't match what we expect, force it " +
+            "to the expected value instead of giving up; useful if a repo moved.")
     optlist = parser.parse_args()
     source_dir = optlist.source_directory or getcwd()
     options = {}
@@ -45,7 +48,7 @@ def run():
         root_url = url_from_directory(source_dir, include_commit = False)
         root = Subproject.create("root", root_url, source_dir, {}, toplevel = True)
         root.update(optlist.clean)
-    generate_cmake_script(source_dir, print_tree=optlist.verbose, options=options, clean=optlist.clean, clobber = optlist.clobber)
+    generate_cmake_script(source_dir, print_tree=optlist.verbose, options=options, clean=optlist.clean, clobber = optlist.clobber, fix_remotes = optlist.fix_remotes)
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
implemented only in the git case to switch remote if it doesn't match instead of throwing a fit; useful if a repo from the catalog changed URL
