### PR TITLE
Extract full artifacts zip

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -939,8 +939,11 @@ class GitlabSubproject(Subproject):
             },
         )
 
-        with urllib.request.urlopen(req) as response:
-            sha1 = self._download_and_hash_with_progress(response, archive_path)
+        try:
+            with urllib.request.urlopen(req) as response:
+                sha1 = self._download_and_hash_with_progress(response, archive_path)
+        except Exception as err:
+            raise QuarkError(f"Error downloading '{req.full_url}'") from err
 
         # Verify or update the SHA1
         print_msg("verifying " + self.parsed_artifact_name, self._print_msg_comment())

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -902,7 +902,7 @@ class GitlabSubproject(Subproject):
 
         # Jobs in latest pipeline
         req = urllib.request.Request(
-            url="%s/api/v4/projects/%s/pipelines/%s/jobs" % (
+            url="%s/api/v4/projects/%s/pipelines/%s/jobs?scope=success" % (
                 self.gitlab_url,
                 urllib.parse.quote_plus(project),
                 pipeline["id"],


### PR DESCRIPTION
Currently the `gitlab+ci://<host>/<project>/artifacts` path without any file is downloaded, but it is not extract-able because the file has no extension.

It is possible to hack gitlab and ask for `gitlab+ci://<host>/<project>/artifacts.zip` (in fact  `artifacts.whatever`), that extension is ignored on gitlab side, but it is used by quark.

Instead, gitlab is providing us in the headers the filename for the returned data as `artifacts.zip`, in general that name is the name of the file we are asking for, but in the `artifacts` case it is different. In this PR we use `response.headers.get_filename()` to have back the `parsed_artifact_name`, that turns out to be a `zip` file and so the extract machinery works as expected.

:warning: this may break the compatibility because quark will start saving the artifacts as `artifacts.zip` instead of `artifacts`.