### PR TITLE
Exit with 1 when requesting an invalid subcommand

### DIFF
--- a/bin/quark
+++ b/bin/quark
@@ -20,6 +20,7 @@ def main():
         print("Available commands:")
         for cmd, _ in sorted(commands):
             print(" %s" % cmd)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Quark prints the available command list when no command or an invalid command was requested. This can be considered an error and we should exit with a status code != 0, so that e.g. CI pipelines can promptly fail.