### PR TITLE
Get GitLab token from system's keyring

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -1,25 +1,32 @@
-import logging
-import json
-import os
-from os.path import exists, join, isdir
-from subprocess import PIPE, Popen, CalledProcessError
-from urllib.parse import urlparse
-from quark.utils import cmake_escape
 import hashlib
 import itertools
+import json
+import logging
+import os
 import shutil
 import stat
 import sys
-import tempfile
 import tarfile
-import zipfile
+import tempfile
 import urllib.parse
 import urllib.request
-
 import xml.etree.ElementTree as ElementTree
+import zipfile
+from os.path import exists, isdir, join
+from subprocess import PIPE, CalledProcessError, Popen
+from urllib.parse import urlparse
 
-from quark.utils import DirectoryContext as cd, fork, log_check_output, print_msg
-from quark.utils import freeze_file, dependency_file, mkdir, load_conf
+from quark.utils import DirectoryContext as cd
+from quark.utils import (
+    cmake_escape,
+    dependency_file,
+    fork,
+    freeze_file,
+    load_conf,
+    log_check_output,
+    mkdir,
+    print_msg,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -818,7 +818,7 @@ class GitlabSubproject(Subproject):
 
         # Try private token variables, in order of importance. GITLAB_PRIVATE_TOKEN is commonly used
         # by python-gitlab's "gitlab" CLI tool, whereas GITLAB_TOKEN is used by GitLab's "glab" CLI
-        # tool.
+        # tool. In any case, you should prefer setting the Quark-specific QUARK_GITLAB_PRIVATE_TOKEN first.
         env_vars = ("QUARK_GITLAB_PRIVATE_TOKEN", "GITLAB_PRIVATE_TOKEN", "GITLAB_TOKEN")  # fmt: skip
         for var in env_vars:
             if var in os.environ:

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -816,9 +816,10 @@ class GitlabSubproject(Subproject):
     def _gitlab_setup(self, url):
         self.gitlab_url = "https://" + url.netloc  # Enforce HTTPS for now.
 
-        # Try private token variables, in order of importance. GITLAB_PRIVATE_TOKEN is commonly used
-        # by python-gitlab's "gitlab" CLI tool, whereas GITLAB_TOKEN is used by GitLab's "glab" CLI
-        # tool. In any case, you should prefer setting the Quark-specific QUARK_GITLAB_PRIVATE_TOKEN first.
+        # Try private token variables, in order of importance. GITLAB_PRIVATE_TOKEN is
+        # commonly used by python-gitlab's "gitlab" CLI tool, whereas GITLAB_TOKEN is
+        # used by GitLab's "glab" CLI tool. In any case, you should prefer setting the
+        # Quark-specific QUARK_GITLAB_PRIVATE_TOKEN first.
         env_vars = ("QUARK_GITLAB_PRIVATE_TOKEN", "GITLAB_PRIVATE_TOKEN", "GITLAB_TOKEN")  # fmt: skip
         for var in env_vars:
             if var in os.environ:

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -677,7 +677,6 @@ class SvnSubproject(Subproject):
         return ret
 
     def mirror(self, dst, quick = False):
-        import shutil
         src = self.directory
 
         os.chdir(src)

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -819,7 +819,7 @@ class GitlabSubproject(Subproject):
         # Try private token variables, in order of importance. GITLAB_PRIVATE_TOKEN is commonly used
         # by python-gitlab's "gitlab" CLI tool, whereas GITLAB_TOKEN is used by GitLab's "glab" CLI
         # tool.
-        env_vars = ("QUARK_GITLAB_PRIVATE_TOKEN", "GITLAB_PRIVATE_TOKEN", "GITLAB_TOKEN")
+        env_vars = ("QUARK_GITLAB_PRIVATE_TOKEN", "GITLAB_PRIVATE_TOKEN", "GITLAB_TOKEN")  # fmt: skip
         for var in env_vars:
             if var in os.environ:
                 self.gitlab_token = os.environ[var]

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -2,8 +2,7 @@ import logging
 import json
 import os
 from os.path import exists, join, isdir
-from shutil import rmtree
-from subprocess import call, PIPE, Popen, CalledProcessError, run
+from subprocess import PIPE, Popen, CalledProcessError
 from urllib.parse import urlparse
 from quark.utils import cmake_escape
 import hashlib


### PR DESCRIPTION
This PR adds an optional integration with the Python [keyring](https://pypi.org/project/keyring/) package in order to obtain the GitLab token from the system's keyring.

Suggested review strategy: commit-by-commit