### PR TITLE
Add "quark run"

### DIFF
--- a/quark/entrypoints.py
+++ b/quark/entrypoints.py
@@ -1,4 +1,4 @@
-from quark import checkout, freeze, status, update, mirror, foreach, query
+from quark import checkout, freeze, status, update, mirror, foreach, query, run
 
 commands = [
     ('checkout', checkout.run),
@@ -7,7 +7,8 @@ commands = [
     ('update', update.run),
     ('mirror', mirror.run),
     ('foreach', foreach.run),
-    ('query', query.run)
+    ('query', query.run),
+    ('run', run.run)
 ]
 
 aliases = [('co', 'checkout'),
@@ -15,7 +16,8 @@ aliases = [('co', 'checkout'),
            ('fz', 'freeze'),
            ('st', 'status'),
            ('fe', 'foreach'),
-           ('q', 'query')]
+           ('q', 'query'),
+           ('r', 'run')]
 
 def mk_setup_entry_points():
     res = ["quark=quark.cli:main"]

--- a/quark/run.py
+++ b/quark/run.py
@@ -1,0 +1,30 @@
+from os import environ, getcwd, pathsep
+from os.path import exists, join
+from subprocess import call
+from sys import argv, exit
+
+from quark.subproject import Subproject
+
+
+def run():
+    if len(argv) < 2:
+        print("Not enough arguments")
+        exit(1)
+
+    paths = []
+    _, modules = Subproject.create_dependency_tree(getcwd(), update=False)
+    for module in modules.values():
+        for path in module.quark_run_paths:
+            module_path = join(module.directory, path)
+            if not exists(module_path):
+                continue
+            paths.append(module_path)
+
+    new_env = environ.copy()
+    new_env["PATH"] = pathsep.join(paths) + pathsep + new_env["PATH"]
+
+    exit(call(argv[1:], env=new_env))
+
+
+if __name__ == "__main__":
+    run()

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -230,12 +230,14 @@ main project abspath: %s""" % (name, uri, source_dir, target_dir_rp, source_dir_
 
                 def do_add_module(name, depobject):
                     external_project = depobject.get('external_project', False)
+                    quark_run_paths = depobject.get('quark_run_paths', ['bin'])
                     add_module(current_module, name,
                                freeze_dict.get(name, depobject.get('url', None)),
                                depobject.get('options', {}),
                                depobject,
                                exclude_from_cmake=depobject.get('exclude_from_cmake', external_project),
-                               external_project=external_project
+                               external_project=external_project,
+                               quark_run_paths=quark_run_paths
                                )
 
                 for name, depobject in conf.get('depends', {}).items():
@@ -254,7 +256,7 @@ main project abspath: %s""" % (name, uri, source_dir, target_dir_rp, source_dir_
         root.set_local_ignores(subprojects_dir, modules.values())
         return root, modules
 
-    def __init__(self, name=None, directory=None, options=None, conf={}, exclude_from_cmake=False, external_project=False, toplevel=False):
+    def __init__(self, name=None, directory=None, options=None, conf={}, exclude_from_cmake=False, external_project=False, toplevel=False, quark_run_paths=list()):
         self.conf = conf
         self.parents = set()
         self.children = set()
@@ -264,6 +266,7 @@ main project abspath: %s""" % (name, uri, source_dir, target_dir_rp, source_dir_
         self.exclude_from_cmake = exclude_from_cmake
         self.external_project = external_project
         self.toplevel = toplevel
+        self.quark_run_paths = quark_run_paths
 
     def __hash__(self):
         return self.name.__hash__()

--- a/tests/run/README.md
+++ b/tests/run/README.md
@@ -1,0 +1,6 @@
+# How to run tests
+
+- Install [cram](https://bitheap.org/cram/).
+  - On Ubuntu: `sudo apt install -y python3-cram`
+- Run the tests with `cram tests`:
+  - On Ubuntu: `cram3 tests`

--- a/tests/run/cram_dir/test_dir_1/subprojects.quark
+++ b/tests/run/cram_dir/test_dir_1/subprojects.quark
@@ -1,0 +1,13 @@
+{
+  "depends": {
+    "test_dir_2": {
+      "url": "git+file://PH_TESTDIR2"
+    },
+    "test_dir_3": {
+      "url": "git+file://PH_TESTDIR3",
+      "quark_run_paths": [
+        "bin2"
+      ]
+    }
+  }
+}

--- a/tests/run/cram_dir/test_dir_2/bin/example_test_dir_2
+++ b/tests/run/cram_dir/test_dir_2/bin/example_test_dir_2
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "It works (test_dir_2)"

--- a/tests/run/cram_dir/test_dir_3/bin2/example_test_dir_3
+++ b/tests/run/cram_dir/test_dir_3/bin2/example_test_dir_3
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "It works (test_dir_3)"

--- a/tests/run/run.t
+++ b/tests/run/run.t
@@ -1,0 +1,37 @@
+# Setup few testing env variables
+  $ CRAMPTESTDIR=$PWD
+  $ REPOS=$CRAMPTESTDIR/repos
+  $ _QUARK=$TESTDIR/../../bin/quark
+
+# Copy all the test directories
+  $ mkdir repos && cd repos && cp -r $TESTDIR/cram_dir/test_dir_* ./
+
+# Edit all urls in subprojects
+  $ cd test_dir_1 &&
+  > sed -i -e "s|PH_TESTDIR2|$REPOS/test_dir_2|g" subprojects.quark &&
+  > sed -i -e "s|PH_TESTDIR3|$REPOS/test_dir_3|g" subprojects.quark &&
+  > cd ..
+
+# Setup the fake git repos
+  $ cd test_dir_1 && git -c init.defaultBranch=initial init > /dev/null && git add * && git commit -m "1st commit" > /dev/null && cd ..
+  $ cd test_dir_2 && git -c init.defaultBranch=initial init > /dev/null && git add * && git commit -m "1st commit" > /dev/null && cd ..
+  $ cd test_dir_3 && git -c init.defaultBranch=initial init > /dev/null && git add * && git commit -m "1st commit" > /dev/null && cd ..
+
+# Clone the root testing git repo
+  $ cd $CRAMPTESTDIR
+  $ mkdir checkout && cd checkout
+  $ git clone file://$REPOS/test_dir_1 > /dev/null 2>&1
+
+# Quark UP from the root
+  $ cd test_dir_1
+  $ $_QUARK up > /dev/null 2>&1
+
+# Check that we have downloaded the expected dependencies
+  $ test -d lib/test_dir_2
+  $ test -d lib/test_dir_3
+
+# Check that "quark run" works
+  $ $_QUARK run example_test_dir_2 2>&1 | grep -v '^quark:'
+  It works (test_dir_2)
+  $ $_QUARK run example_test_dir_3 2>&1 | grep -v '^quark:'
+  It works (test_dir_3)


### PR DESCRIPTION
This adds each submodule's "bin" directory to the path and will make it
easier to consume development tools that are downloaded by Quark (e.g.
by using the "devdepends" table in `subprojects.quark` to e.g. download
and use a project-specific version of CMake).

The directory itself is configurable via the `quark_run_paths` option
that accepts a list of module-relative paths that should be considered.
Its default value is `["bin"]`, this way most packages will work out of
the box by following the existing convention of putting executables in a
`bin` directory.

The current implementation currently considers all modules in the tree,
in order to keep things simple (otherwise we'd have to add provenance
information to all dependencies which would make this patch a bit more
invasive).

In the future we may want to consider only "devdepends" dependencies but
we would like to play with this feature in real world scenarios first.