### PR TITLE
Fix for toplevel remote url without scheme part

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -115,12 +115,7 @@ class Subproject:
         clobber_backup_path = os.path.join(source_dir_rp, 'clobbered.quark')
         if clobber and os.path.exists(clobber_backup_path):
             raise QuarkError('clobbered.quark already exists; remove it to proceed')
-        root_url = url
-        try:
-            root_url = url_from_directory(source_dir)
-        except QuarkError:
-            pass
-        root = Subproject.create("root", root_url, source_dir, {}, {}, toplevel = True)
+        root = Subproject.create("root", url, source_dir, {}, {}, toplevel = True)
         if url and update:
             root.checkout()
         conf = load_conf(source_dir)

--- a/tests/foreach/foreach.t
+++ b/tests/foreach/foreach.t
@@ -33,8 +33,6 @@
 
 # Test foreach's output with a simple echo of its env variables
   $ $_QUARK foreach 'echo $name $sm_path $displaypath $sha1 $toplevel $rev $version_control'
-  .* (re)
-  .* (re)
   Entering test_dir_2
   test_dir_2 src/test_dir_2 src/test_dir_2 .+ /tmp/cramtests-.*/foreach.t/checkout/test_dir_1 git (re)
   Entering test_dir_3
@@ -44,8 +42,6 @@
 
 # Test foreach with a shell script
   $ $_QUARK foreach $TESTDIR/foreach.sh
-  .* (re)
-  .* (re)
   Entering test_dir_2
   name: test_dir_2
   sm_path: src/test_dir_2
@@ -80,8 +76,6 @@
 # The check for the hashes is done by the regex '[a-fA-F0-9]{40}'
 # (Match exactly 40 times any word character)
   $ $_QUARK foreach 'echo $name $sm_path $displaypath $sha1 $toplevel $rev $version_control'
-  .* (re)
-  .* (re)
   Entering test_dir_2
   test_dir_2 src/test_dir_2 src/test_dir_2 [a-fA-F0-9]{40} /tmp/cramtests-.*/foreach.t/checkout/test_dir_1 git (re)
   Entering test_dir_3


### PR DESCRIPTION
Some operations failed when the top level remote url didn't contain a scheme part like the ones GitHub suggests for ssh.