### PR TITLE
GitSubproject: shove non-URL-like remotes in a custom URL

### DIFF
--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -324,10 +324,10 @@ class GitSubproject(Subproject):
                 self.ref_type = 'tag'
             elif 'branch' in fragment:
                 self.ref = 'origin/%s' % fragment['branch']
-        self.url = url._replace(fragment='')._replace(scheme=url.scheme.replace('git+', ''))
+        self.remote = url._replace(fragment='')._replace(scheme=url.scheme.replace('git+', '')).geturl()
 
     def same_checkout(self, other):
-        if isinstance(other, GitSubproject) and (self.url, self.ref, self.conf.get("shallow", False)) == (other.url, other.ref, other.conf.get("shallow", False)):
+        if isinstance(other, GitSubproject) and (self.remote, self.ref, self.conf.get("shallow", False)) == (other.remote, other.ref, other.conf.get("shallow", False)):
             return True
         return False
 
@@ -347,7 +347,7 @@ class GitSubproject(Subproject):
             os.mkdir(self.directory)
             with cd(self.directory):
                 fork(['git', 'init'])
-                fork(['git', 'remote', 'add', 'origin', self.url.geturl()])
+                fork(['git', 'remote', 'add', 'origin', self.remote])
                 fork(['git', 'fetch', '--depth', '1', 'origin', self.noremote_ref()])
                 fork(['git', '-c', 'advice.detachedHead=false', 'checkout', self.ref, '--'])
         else:
@@ -359,7 +359,7 @@ class GitSubproject(Subproject):
             # git clone -n + git checkout would suffice
             if shallow and self.ref_type != 'commit' and self.ref != 'origin/HEAD':
                 extra_opts += ['-b', self.noremote_ref()]
-            fork(['git', 'clone', '-n'] + extra_opts + ['--', self.url.geturl(), self.directory])
+            fork(['git', 'clone', '-n'] + extra_opts + ['--', self.remote, self.directory])
             with cd(self.directory):
                 opts = [self.ref]
                 # If it's a branch, create a remote-tracking one
@@ -376,10 +376,10 @@ class GitSubproject(Subproject):
                     current_origin = log_check_output(['git', 'config', '--get', 'remote.origin.url']).strip().decode('utf-8')
                 except CalledProcessError:
                     current_origin = None
-                if current_origin != self.url.geturl():
+                if current_origin != self.remote:
                     if fix_remotes:
-                        logger.info("Fixing incorrect remote in %s directory (%s -> %s)" % (self.directory, current_origin, self.url.geturl()))
-                        fork(['git', 'remote', 'set-url', 'origin', self.url.geturl()])
+                        logger.info("Fixing incorrect remote in %s directory (%s -> %s)" % (self.directory, current_origin, self.remote))
+                        fork(['git', 'remote', 'set-url', 'origin', self.remote])
                     else:
                         raise QuarkError("""
 
@@ -387,7 +387,7 @@ Directory '%s' is a git repository,
 but its remote 'origin' (%r)
 does not match what we expect (%r).
 
-Please either remove the local clone, or fix its remote.""" % (self.directory, current_origin, self.url.geturl()))
+Please either remove the local clone, or fix its remote.""" % (self.directory, current_origin, self.remote))
                 if self.conf.get("shallow", False):
                     # git fetch with shallow clones isn't very smart, and
                     # re-fetches stuff that we already have; try to avoid this

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -495,7 +495,7 @@ Please either remove the local clone, or fix its remote.""" % (self.directory, c
             except CalledProcessError:
                 raise QuarkError("Cannot obtain remote")
             commit = log_check_output(['git', 'log', '-1', '--format=%H'], universal_newlines=True)[:-1]
-        ret = 'git+%s' % (origin,)
+        ret = 'git+' + origin if not origin.startswith('git+') else origin
         if include_commit:
             ret += '#commit=%s' % (commit,)
         return ret

--- a/quark/subproject.py
+++ b/quark/subproject.py
@@ -324,7 +324,14 @@ class GitSubproject(Subproject):
                 self.ref_type = 'tag'
             elif 'branch' in fragment:
                 self.ref = 'origin/%s' % fragment['branch']
-        self.remote = url._replace(fragment='')._replace(scheme=url.scheme.replace('git+', '')).geturl()
+        if url.scheme == 'quarkunknown':
+            # unpack opaque, non-URL-style remotes, such as scp-style
+            # (user@host.xy:path/repo.git) or local paths (see
+            # url_from_directory)
+            self.remote = urllib.parse.unquote(url.path)[1:]
+        else:
+            # "regular" URLs (drop git+ prefix and fragment)
+            self.remote = url._replace(fragment='')._replace(scheme=url.scheme.replace('git+', '')).geturl()
 
     def same_checkout(self, other):
         if isinstance(other, GitSubproject) and (self.remote, self.ref, self.conf.get("shallow", False)) == (other.remote, other.ref, other.conf.get("shallow", False)):
@@ -495,6 +502,21 @@ Please either remove the local clone, or fix its remote.""" % (self.directory, c
             except CalledProcessError:
                 raise QuarkError("Cannot obtain remote")
             commit = log_check_output(['git', 'log', '-1', '--format=%H'], universal_newlines=True)[:-1]
+        parsed = None
+        try:
+            parsed = urllib.parse.urlparse(origin)
+        except:
+            # shouldn't really happen, urlparse shoves everything it doesn't
+            # understand in path
+            pass
+        if parsed is None or parsed.scheme == '':
+            # This is a non-URL-style remote, such as an scp-style
+            # (user@host.xy:path/repo.git) or local path.
+            # To keep up the quark fiction about every subproject being
+            # representable by an URL, we shove the string opaquely in the path
+            # part of a fake URL, that is recognized by __init__ above.
+            origin = 'quarkunknown:///' + urllib.parse.quote(origin)
+
         ret = 'git+' + origin if not origin.startswith('git+') else origin
         if include_commit:
             ret += '#commit=%s' % (commit,)


### PR DESCRIPTION
GitSubproject: shove non-URL-like remotes in a custom URL
    
to keep up the quark fiction of every repo being representable by an URL, but supporting arbitrary non-URL strings for git repo remotes (such as scp-style `user@host.xy:path/repo.git` or plain local paths).
    
This fixes the crashes that happened when using quark on a toplevel repo that was cloned with a non-URL remote string.
